### PR TITLE
🔧 Fix API URL for Netlify production

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,7 +12,7 @@ const nextConfig = {
   
   // Environment variables
   env: {
-    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001',
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || (process.env.NODE_ENV === 'production' ? '/.netlify/functions' : 'http://localhost:3001'),
     NEXT_PUBLIC_WS_URL: process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:3002',
   },
   


### PR DESCRIPTION
✅ Auto-detect production environment and use /.netlify/functions ✅ Fallback to localhost only in development
✅ This fixes the 'Connection Error' by ensuring API calls go to Netlify Functions

The frontend will now automatically use:
- Production: /.netlify/functions (relative URL)
- Development: http://localhost:3001

No need to manually set NEXT_PUBLIC_API_BASE_URL environment variable.